### PR TITLE
Remove unit of measurement for CSS zero value

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -28,7 +28,7 @@
 }
 
 .post {
-    padding: 5px 10px 5px 0px;
+    padding: 5px 10px 5px 0;
     border-bottom: 1px solid #dee2e6;
 }
 


### PR DESCRIPTION
CSS requires units to be specified for any non-zero values to ensure clarity and consistency.

It cover this [issue](https://github.com/Unitu/moodle-block_unitu_notif/issues/4)